### PR TITLE
Accessor for "maximized"

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXDecorator.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXDecorator.java
@@ -581,6 +581,15 @@ public class JFXDecorator extends VBox {
     public final void setCustomMaximize(final boolean customMaximize) {
         this.customMaximizeProperty().set(customMaximize);
     }
+    
+    /**
+     * the currrent custom maximized state
+     *
+     * @return whether the window is maximized or not
+     */
+    public final boolean isMaximized() {
+        return this.maximized;
+    }
 
     /**
      * @param maximized


### PR DESCRIPTION
The custom maximization process does not change the stage's maximized state. I think it is useful to have this accessor in this class.